### PR TITLE
Create outermost context

### DIFF
--- a/ticketmate_client/src/Shared/OuterContext.tsx
+++ b/ticketmate_client/src/Shared/OuterContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, ReactNode } from 'react';
+import {User} from '../client/types.gen'
+
+type Project = {
+    guid?: string;
+    name?: string;
+    isActive?: boolean;
+};
+
+
+type Ticket = {
+    guid?: string;
+    title?: string;
+    description?: string;
+    statusId?: number;
+    priorityId?: number;
+};
+
+
+type DashBoardProps = {
+    user: User | null;
+    projects: Project[];
+    tickets: Ticket[];
+}
+
+
+
+const OuterContext = createContext<DashBoardProps | undefined>(undefined)
+
+
+
+const OuterContextProvider = ({ children }: { children: ReactNode }) => {
+
+    const user: User = {
+        guid: "1337",
+        phoneNumber: "317-867-5309",
+        firstName: "John",
+        lastName: "Doe",
+        email: "john.doe@example.com",
+        avatar: "avatarUrl",
+        isActive: true
+    };
+
+    const projects: Project[] = [];
+    const tickets: Ticket[] = [];
+
+    return(
+        <OuterContext.Provider value={{user, projects, tickets}}>
+            {children}
+        </OuterContext.Provider>
+    )}
+
+export {OuterContext, OuterContextProvider}

--- a/ticketmate_client/src/main.tsx
+++ b/ticketmate_client/src/main.tsx
@@ -3,13 +3,16 @@ import { createRoot } from 'react-dom/client'
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import App from './App.tsx'
+import { OuterContextProvider } from './Shared/OuterContext.tsx'
 
 const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <OuterContextProvider>
+        <App />
+      </OuterContextProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </StrictMode>


### PR DESCRIPTION
Hello friends, this PR adds context containing the `user`, `projects`, and `tickets`. The context provider wraps the <App /> component, meaning any of its children can access those variables.

Right now I just have placeholder data defined in the OuterContext.tsx file, I imagine eventually this will be refactored to use actual data from the user but I think this is okay for now. 

I would love code review and any thoughts on this!

Cheers, 
Alec